### PR TITLE
Added 'pip' as explicit (conda) dependency

### DIFF
--- a/knime_extension/geospatial_env.yml
+++ b/knime_extension/geospatial_env.yml
@@ -15,5 +15,6 @@ dependencies:
   - pulp
   - pysal
   - seaborn
+  - pip
   - pip:
     - pyecharts


### PR DESCRIPTION
... this is because this is what I received on my Linux console without having it listed explicitely (1000+++ times):

Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.