### PR TITLE
360 instead of returning wrong results the osrm distance matrix node should return an error if the service is unavailable

### DIFF
--- a/knime_extension/src/nodes/spatialnetwork.py
+++ b/knime_extension/src/nodes/spatialnetwork.py
@@ -790,9 +790,9 @@ class OSRMDistanceMatrix:
                     else:
                         df.loc[ns:ne, self._COL_GEOMETRY] = temp_route
             else:
-                raise RuntimeError("OSRM server not available")
+                knut.LOGGER.warning(f"No route found from:{ns} to :{ne}")
         except Exception as err:
-            knut.LOGGER.warning(f"Error finding route from:{ns} to :{ne}. Error: {err}")
+            knut.LOGGER.warning(f"OSRM server not available. Error: {err}")
 
     def execute(self, exec_context: knext.ExecutionContext, left_input, right_input):
         from shapely.geometry import LineString

--- a/knime_extension/src/nodes/spatialnetwork.py
+++ b/knime_extension/src/nodes/spatialnetwork.py
@@ -790,7 +790,7 @@ class OSRMDistanceMatrix:
                     else:
                         df.loc[ns:ne, self._COL_GEOMETRY] = temp_route
             else:
-                knut.LOGGER.warning(f"No route found from:{ns} to :{ne}")
+                raise RuntimeError("OSRM server not available")
         except Exception as err:
             knut.LOGGER.warning(f"Error finding route from:{ns} to :{ne}. Error: {err}")
 


### PR DESCRIPTION
Just revise one line. But it seems I can not raise an error. you can test it by revising the server to a wrong URL "https://router1.project-osrm.org"